### PR TITLE
Replaced OS-specific commands in package.json build with Maven plugins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .idea
 target/
 *.iml
-backend/src/main/resources/static/*

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -59,6 +59,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
+      <!-- ensure npm install with no-optional is called -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -67,7 +68,7 @@
         </configuration>
         <executions>
           <execution>
-            <id>npm run-script build</id>
+            <id>npm install (initialize)</id>
             <goals>
               <goal>exec</goal>
             </goals>
@@ -75,9 +76,59 @@
             <configuration>
               <executable>npm</executable>
               <arguments>
+                <argument>install</argument>
+                <argument>--no-optional</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm run-script build</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <executable>npm</executable>
+              <arguments>
                 <argument>run</argument>
                 <argument>build</argument>
               </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- include generated resources in clean phase -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../frontend/build</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <!-- After build copy build results to backend/target -->
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes/static</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>../frontend/build</directory>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "rm -rf ../backend/src/main/resources/static/* && npm i && react-scripts build && mv ./build/* ../backend/src/main/resources/static",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
- remove OS-specific commands in package.json (so building on Win also works)
- instead perform npm initialize, copying and cleanup of build files with Maven plugins
- copy build results directly to target folder, making static folder in backend and its cleanup obsolete.