### PR TITLE
Add application.yaml in test resources.

### DIFF
--- a/backend/src/main/java/com/camunda/start/processing/ProjectGenerator.java
+++ b/backend/src/main/java/com/camunda/start/processing/ProjectGenerator.java
@@ -48,6 +48,7 @@ public class ProjectGenerator {
 
   protected static final String APPLICATION_CLASS_NAME = "Application.java";
   protected static final String APPLICATION_YAML_NAME = "application.yaml";
+  protected static final String APPLICATION_YAML_TEST_NAME = "application.yaml.test";
   protected static final String APPLICATION_POM_NAME = "pom.xml";
   protected static final String APPLICATION_BPMN_NAME = "process.bpmn";
   protected static final String APPLICATION_TEST_CASE_NAME = "WorkflowTest.java";
@@ -88,9 +89,11 @@ public class ProjectGenerator {
     if (isCamundaAssert) {
       byte[] logbackTestConfig = processByFileName(APPLICATION_LOGCONFIG_NAME);
       byte[] testCase = processByFileName(APPLICATION_TEST_CASE_NAME);
+      byte[] applicationYamlTest = processByFileName(APPLICATION_YAML_TEST_NAME);
 
       entries.add(new ByteSource(projectName + TEST_JAVA_PATH + packageName + "/" + APPLICATION_TEST_CASE_NAME, testCase));
       entries.add(new ByteSource(projectName + TEST_RESOURCES_PATH + APPLICATION_LOGCONFIG_NAME, logbackTestConfig));
+      entries.add(new ByteSource(projectName + TEST_RESOURCES_PATH + APPLICATION_YAML_NAME, applicationYamlTest));
     }
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/backend/src/main/resources/com/camunda/start/templates/application.yaml.test.vm
+++ b/backend/src/main/resources/com/camunda/start/templates/application.yaml.test.vm
@@ -1,0 +1,2 @@
+camunda.bpm.job-execution:
+  enabled: false


### PR DESCRIPTION
This PR prevents an issue with the current setup where the generated project does not include the expected configuration for the generated unit testing setup. Specifically, it adds an application.yaml file to the test resources, which disables the JobExecutor in the way that matches the Spring Boot initialisation of the unit tests. Without this, the JobExecutor is still activated as part of the test, even though the process engine configuration disables it. This is because the Spring Boot starter always acts on the event that the Process Application was started and then activates the JobExecutor, regardless of the engine's configuration.

* Add a new resource to the generated entries that contains test-specific configuration, disabling the JobExecutor;
* Add resource inclusion as ZipEntrySource so it is generated into the resulting project;